### PR TITLE
feat: atualiza componentes e adiciona relatórios de 18 e 22 de julho(Suporte Multi-Área e Nova Pesquisa no Frontend do PrevInfoBot)

### DIFF
--- a/src/components/ConsultaForm.jsx
+++ b/src/components/ConsultaForm.jsx
@@ -1,37 +1,57 @@
-import { useState } from "react"; 
+import { useState, useEffect } from "react";
 import axios from "axios";
 
-export default function ConsultaForm({ setResposta, setEmConsulta, emConsulta }) {
-  const [pergunta, setPergunta] = useState("");
+export default function ConsultaForm({ setResposta, setEmConsulta, emConsulta, setPergunta, setArea, resetForm }) {
+  const [perguntaLocal, setPerguntaLocal] = useState("");
+  const [areaLocal, setAreaLocal] = useState("previdenciario");
+  const token = localStorage.getItem("token");
+
+  // Sincroniza estado local com resetForm
+  useEffect(() => {
+    setPerguntaLocal("");
+    setAreaLocal("previdenciario");
+  }, [resetForm]);
 
   const handleSubmit = async (e) => {
     e.preventDefault();
+    if (!perguntaLocal.trim()) {
+      alert("Por favor, digite uma pergunta válida.");
+      return;
+    }
     if (typeof setEmConsulta === "function") setEmConsulta(true);
 
     try {
-      const token = localStorage.getItem("token");
-      const res = await axios.post("http://localhost:8000/consultar",
-        { pergunta },
+      const res = await axios.post(
+        "http://localhost:8000/consultar",
+        { pergunta: perguntaLocal, area: areaLocal },
         { headers: { Authorization: `Bearer ${token}` } }
       );
-
-      if (typeof setResposta === "function") {
-        setResposta(res.data.resposta);
-      }
+      if (typeof setResposta === "function") setResposta(res.data.resposta);
+      if (typeof setPergunta === "function") setPergunta(perguntaLocal);
+      if (typeof setArea === "function") setArea(areaLocal);
     } catch (err) {
       console.error("Erro ao consultar:", err);
-      if (typeof setResposta === "function") {
-        setResposta("Erro ao consultar.");
-      }
+      alert(`Erro ao consultar: ${err.response?.data?.detail || err.message}`);
+    } finally {
+      if (typeof setEmConsulta === "function") setEmConsulta(false);
     }
   };
 
   return (
     <form onSubmit={handleSubmit} className="bg-white p-6 rounded-lg shadow-md animate-fadeIn space-y-4">
+      <select
+        value={areaLocal}
+        onChange={(e) => setAreaLocal(e.target.value)}
+        className="w-full p-3 border rounded focus:outline-none focus:ring-2 focus:ring-blue-500"
+      >
+        <option value="previdenciario">Previdenciário</option>
+        <option value="consumidor">Consumidor</option>
+        <option value="processual_civil">Processual Civil</option>
+      </select>
       <input
         type="text"
-        value={pergunta}
-        onChange={(e) => setPergunta(e.target.value)}
+        value={perguntaLocal}
+        onChange={(e) => setPerguntaLocal(e.target.value)}
         placeholder="Digite sua dúvida jurídica"
         required
         className="w-full p-3 border rounded focus:outline-none focus:ring-2 focus:ring-blue-500"

--- a/src/components/RespostaBox.jsx
+++ b/src/components/RespostaBox.jsx
@@ -1,13 +1,50 @@
-export default function RespostaBox({ resposta }) {
+import { useState } from "react";
+import axios from "axios";
+
+export default function RespostaBox({ resposta, pergunta, area, resetForm }) {
+  const [feedbackEnviado, setFeedbackEnviado] = useState(false);
+  const token = localStorage.getItem("token");
+
+  const enviarFeedback = async () => {
+    const feedback = prompt("Digite seu feedback sobre a resposta:");
+    if (!feedback) return;
+
+    try {
+      await axios.post(
+        "http://localhost:8000/feedback",
+        { pergunta, resposta, feedback },
+        { headers: { Authorization: `Bearer ${token}` } }
+      );
+      setFeedbackEnviado(true);
+      alert("Feedback enviado com sucesso!");
+    } catch (err) {
+      alert("Erro ao enviar feedback: " + err.response?.data?.detail || err.message);
+    }
+  };
+
   if (!resposta || resposta === "") return null;
 
   return (
     <div className="bg-white border-l-4 border-blue-600 p-4 mt-6 rounded shadow-md animate-fadeIn">
-      <h3 className="text-lg font-bold text-blue-700 mb-2">📄 Resposta do Previnfobot:
-      </h3>
-      <p className="whitespace-pre-line text-gray-800">
-        {resposta.result || JSON.stringify(resposta)}
-      </p>
+      <h3 className="text-lg font-bold text-blue-700 mb-2">📄 Resposta do Previnfobot:</h3>
+      <p className="whitespace-pre-line text-gray-800">{resposta}</p>
+      <div className="mt-4 space-x-4">
+        <button
+          onClick={enviarFeedback}
+          disabled={feedbackEnviado}
+          className={`px-4 py-2 rounded text-white font-semibold transition-all ${
+            feedbackEnviado ? "bg-gray-400 cursor-not-allowed" : "bg-blue-600 hover:bg-blue-800"
+          }`}
+        >
+          {feedbackEnviado ? "Feedback Enviado" : "Enviar Feedback"}
+        </button>
+        <button
+          onClick={resetForm}
+          className="px-4 py-2 rounded text-white font-semibold bg-green-600 hover:bg-green-800 transition-all"
+        >
+          Nova Pesquisa
+        </button>
+      </div>
     </div>
   );
 }

--- a/src/pages/ConsultaApp.jsx
+++ b/src/pages/ConsultaApp.jsx
@@ -6,9 +6,14 @@ import SidebarLayout from "../components/SidebarLayout";
 export default function ConsultaApp() {
   const [resposta, setResposta] = useState("");
   const [emConsulta, setEmConsulta] = useState(false);
+  const [pergunta, setPergunta] = useState("");
+  const [area, setArea] = useState("previdenciario");
 
-  const tratarResposta = (texto) => {
-    setResposta(texto);
+  // Função para resetar o formulário
+  const resetForm = () => {
+    setResposta("");
+    setPergunta("");
+    setArea("previdenciario");
     setEmConsulta(false);
   };
 
@@ -16,14 +21,20 @@ export default function ConsultaApp() {
     <SidebarLayout>
       <div className="p-6 max-w-2xl mx-auto bg-white rounded-lg shadow-md animate-fadeIn">
         <h2 className="text-2xl font-bold mb-6 text-gray-800">🔎 Consulta Jurídica</h2>
-
         <ConsultaForm
-          setResposta={tratarResposta}
+          setResposta={setResposta}
           emConsulta={emConsulta}
           setEmConsulta={setEmConsulta}
+          setPergunta={setPergunta}
+          setArea={setArea}
+          resetForm={resetForm}
         />
-
-        <RespostaBox resposta={resposta} />
+        <RespostaBox
+          resposta={resposta}
+          pergunta={pergunta}
+          area={area}
+          resetForm={resetForm}
+        />
       </div>
     </SidebarLayout>
   );

--- a/src/relatorios/relatorio_18_07_2025.md
+++ b/src/relatorios/relatorio_18_07_2025.md
@@ -1,0 +1,46 @@
+# Relatório Técnico - 18/07/2025
+
+## 📌 Descrição
+Este relatório documenta o ajuste de caminhos de arquivos utilizados na aplicação **AdvogPT** para o carregamento do índice vetorial FAISS, utilizado no fluxo de recuperação de contexto com LangChain.
+
+## 🔍 Problema Identificado
+Durante a tentativa de carregar o índice FAISS utilizando `FAISS.load_local()`, foi identificado um erro de caminho incorreto. O caminho estava incorretamente concatenado como:
+
+```
+C:\Users\Samsung\Desktop\AdvogPT\dados\vetores\faiss_index\index.faiss/C:\Users\Samsung\Desktop\AdvogPT\dados\vetores\faiss_index\index.pkl
+```
+
+Esse formato inválido misturava dois caminhos de arquivos diferentes, gerando falha de leitura.
+
+## ✅ Solução Aplicada
+
+Foi realizada a correção, separando corretamente os caminhos esperados para os arquivos:
+
+- `index.faiss`
+- `index.pkl`
+
+Ambos localizados em:
+
+```
+C:\Users\Samsung\Desktop\AdvogPT\dados\vetores\faiss_index\
+```
+
+Com isso, o código foi ajustado da seguinte forma:
+
+```python
+from langchain_community.vectorstores import FAISS
+
+vectorstore = FAISS.load_local(
+    folder_path="C:/Users/Samsung/Desktop/AdvogPT/dados/vetores/faiss_index",
+    embeddings=embeddings,
+    index_name="index"  # Vai buscar "index.faiss" e "index.pkl"
+)
+```
+
+## 🧪 Resultado
+Após a correção, o carregamento do índice foi realizado com sucesso, permitindo a utilização da base vetorial para consultas com RAG (Retrieval-Augmented Generation).
+
+## 👨‍💻 Autor
+Teófilo Nicolau  
+Projeto: AdvogPT  
+Data: 18/07/2025

--- a/src/relatorios/relatorio_22_07_2025.md
+++ b/src/relatorios/relatorio_22_07_2025.md
@@ -1,0 +1,92 @@
+# Relatório do Frontend - PrevInfoBot (22/07/2025)
+
+## O que fizemos hoje
+
+### Confirmação do Suporte Multi-Área
+
+**Ação:**  
+Validamos que o frontend suporta consultas nas três esferas jurídicas (Previdenciário, Consumidor, Processual Civil), enviando os campos `pergunta` e `area` corretamente para o endpoint `/consultar`.
+
+**Motivo:**  
+Garantir que o frontend estivesse alinhado com o backend, que agora processa consultas para múltiplas áreas, enviando `area` como parte do payload (ex.:  
+```json
+{"pergunta": "Qual a idade mínima para o LOAS?", "area": "previdenciario"}
+```)
+
+---
+
+### Implementação do Botão "Nova Pesquisa"
+
+**Ação:**  
+Adicionamos um botão "Nova Pesquisa" ao frontend para recarregar o formulário, limpando os campos e a resposta exibida.
+
+**Modificações:**
+
+- **`src/pages/ConsultaApp.jsx`:**  
+  Adicionamos a função `resetForm` para limpar os estados `resposta`, `pergunta`, `area` (voltando para `"previdenciario"`) e `emConsulta`.  
+  Passamos `resetForm` como prop para `ConsultaForm` e `RespostaBox`.
+
+  ```javascript
+  const resetForm = () => {
+    setResposta("");
+    setPergunta("");
+    setArea("previdenciario");
+    setEmConsulta(false);
+  };
+  ```
+
+- **`src/components/ConsultaForm.jsx`:**  
+  Adicionamos `useEffect` para sincronizar os estados locais `perguntaLocal` e `areaLocal` quando `resetForm` é chamado, garantindo que o formulário reflita o estado resetado.
+
+- **`src/components/RespostaBox.jsx`:**  
+  Adicionamos um botão "Nova Pesquisa" que chama `resetForm`, estilizado com classes Tailwind (`bg-green-600`, `hover:bg-green-800`) para consistência com a UI:
+
+  ```jsx
+  <button
+    onClick={resetForm}
+    className="px-4 py-2 rounded text-white font-semibold bg-green-600 hover:bg-green-800 transition-all"
+  >
+    Nova Pesquisa
+  </button>
+  ```
+
+**Motivo:**  
+Atender à solicitação de permitir que o usuário reinicie o formulário de forma intuitiva, limpando a pergunta, a área (voltando para "Previdenciário") e a resposta exibida, sem recarregar a página.
+
+---
+
+### Testes de Integração
+
+**Ação:**  
+Iniciamos o frontend com `npm run dev` e testamos em `http://localhost:5173/consulta`, verificando:
+
+- Envio de perguntas com diferentes áreas (Previdenciário, Consumidor, Processual Civil).
+- Exibição correta das respostas no `RespostaBox`.
+- Funcionamento do botão "Enviar Feedback", enviando requisições para `/feedback`.
+- Comportamento do botão "Nova Pesquisa", que limpa o formulário e a resposta.
+
+**Motivo:**  
+Garantir que o frontend estivesse integrado com o backend, enviando requisições corretas, exibindo respostas adequadamente, e suportando feedback e reset do formulário sem erros no console do navegador.
+
+---
+
+## Por que fizemos
+
+- **Suporte Multi-Área:**  
+  Para tornar o PrevInfoBot escalável, permitindo consultas em diferentes áreas jurídicas (Previdenciário, Consumidor, Processual Civil) através de um `<select>` amigável no formulário.
+
+- **Botão "Nova Pesquisa":**  
+  Para melhorar a usabilidade, oferecendo uma forma clara e rápida de iniciar uma nova consulta, limpando o formulário e a resposta, mantendo a experiência fluida e intuitiva.
+
+- **Testes:**  
+  Para confirmar que o frontend envia requisições corretas (com `pergunta` e `area`), exibe respostas do backend, suporta feedback, e implementa o reset do formulário sem erros.
+
+---
+
+## Resultados
+
+- **Frontend** suporta consultas nas três esferas, enviando `area` corretamente para o endpoint `/consultar`.
+- **Botão "Nova Pesquisa"** implementado com sucesso, limpando o formulário (pergunta e área) e a resposta exibida.
+- **Interface amigável** com tratamento de erros robusto (alertas detalhados para falhas do backend) e feedback funcional.
+- **Integração com o backend** confirmada, com requisições retornando **200 OK** (logs do Uvicorn).
+- **Experiência do usuário aprimorada**, com uma UI consistente (estilização Tailwind) e funcionalidade de reset.


### PR DESCRIPTION
## 🎨 Pull Request: Suporte Multi-Área e Nova Pesquisa no Frontend do PrevInfoBot

### ✅ O que foi feito

1. **Correção de carregamento FAISS no Frontend**
   - Ajustamos o caminho do índice vetorial FAISS no `rag.py` para evitar falhas de concatenação e garantir que `index.faiss` e `index.pkl` fossem corretamente localizados.

2. **Suporte Multi-Área**
   - O frontend agora envia corretamente os campos `pergunta` e `area` no corpo da requisição para o endpoint `/consultar`.
   - O seletor de área permite alternar entre Previdenciário, Consumidor e Processual Civil.

3. **Botão "Nova Pesquisa"**
   - Adicionado botão que reseta o formulário e limpa a resposta, proporcionando uma experiência de usuário mais fluida.
   - A função `resetForm` foi criada e propagada pelos componentes `ConsultaApp`, `ConsultaForm` e `RespostaBox`.

4. **Estilização**
   - O botão "Nova Pesquisa" segue o padrão visual da aplicação com classes do Tailwind.

5. **Testes de Integração**
   - Realizamos testes com diferentes áreas e confirmamos funcionamento dos endpoints `/consultar` e `/feedback`, além do comportamento esperado do botão de reset.

---

### 🧠 Por que fizemos

- Para alinhar o frontend com o backend, que passou a suportar múltiplas áreas jurídicas.
- Para aprimorar a usabilidade com o botão de reset de pesquisa.
- Para garantir que o envio de dados ao backend esteja correto e que o feedback e consulta funcionem sem erros.

---

### 📊 Resultados

- Suporte completo a consultas nas três áreas jurídicas.
- Formulário resetável com o botão "Nova Pesquisa".
- Integração sólida entre frontend e backend, com respostas 200 OK e feedbacks sendo enviados corretamente.
- Experiência de usuário aprimorada, sem erros no console e com feedback visual adequado.
